### PR TITLE
Rename sweep -> mailboxed

### DIFF
--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -9,7 +9,7 @@ module FRP.Event
   , bus
   , memoize
   , hot
-  , sweep
+  , mailboxed
   , module Class
   , delay
   , ToEvent
@@ -236,8 +236,8 @@ bus f = makeEvent \k -> do
   pure (pure unit)
 
 -- | Takes the entire domain of a and allows for ad-hoc specialization.
-sweep :: forall m s r a. Ord a => MonadST s m => AnEvent m a -> ((a -> AnEvent m Unit) -> r) -> AnEvent m r
-sweep e f = makeEvent \k1 -> do
+mailboxed :: forall m s r a. Ord a => MonadST s m => AnEvent m a -> ((a -> AnEvent m Unit) -> r) -> AnEvent m r
+mailboxed e f = makeEvent \k1 -> do
   r <- liftST $ Ref.new Map.empty
   k1 $ f \a -> makeEvent \k2 -> do
     void $ liftST $ Ref.modify (Map.alter (case _ of

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -21,7 +21,7 @@ import Effect.Class (liftEffect)
 import Effect.Ref as Ref
 import Effect.Unsafe (unsafePerformEffect)
 import FRP.Behavior (Behavior, behavior, gate)
-import FRP.Event (hot, keepLatest, makeEvent, memoize, sampleOn, sweep)
+import FRP.Event (hot, keepLatest, makeEvent, memoize, sampleOn, mailboxed)
 import FRP.Event as Event
 import FRP.Event.Class (class IsEvent, bang, fold)
 import FRP.Event.Legacy as Legacy
@@ -565,11 +565,11 @@ main = do
                   (lift $ RRef.read rf) >>= tell <<< shouldEqual [ Tuple 3 10, Tuple 3 18 ]
                   lift $ unsub
               )
-        describe "Sweep" do
-          it "sweeps" $ liftEffect do
+        describe "Mailboxed" do
+          it "mailboxes" $ liftEffect do
             rf <- Ref.new []
             e <- Event.create
-            unsub <- Event.subscribe (keepLatest $ sweep e.event \f -> f 3 <|> f 4) \i -> Ref.modify_ (cons i) rf
+            unsub <- Event.subscribe (keepLatest $ mailboxed e.event \f -> f 3 <|> f 4) \i -> Ref.modify_ (cons i) rf
             e.push 42
             e.push 43
             e.push 44


### PR DESCRIPTION
Since the individual events act like little mailboxes for each particular value 📬 .