### PR TITLE
Makes mailboxed more robust.

### DIFF
--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -236,21 +236,33 @@ bus f = makeEvent \k -> do
   pure (pure unit)
 
 -- | Takes the entire domain of a and allows for ad-hoc specialization.
-mailboxed :: forall m s r a. Ord a => MonadST s m => AnEvent m a -> ((a -> AnEvent m Unit) -> r) -> AnEvent m r
+mailboxed :: forall m s r a. Ord a => MonadST s m => AnEvent m a -> ((a -> AnEvent m a) -> r) -> AnEvent m r
 mailboxed e f = makeEvent \k1 -> do
   r <- liftST $ Ref.new Map.empty
   k1 $ f \a -> makeEvent \k2 -> do
-    void $ liftST $ Ref.modify (Map.alter (case _ of
-      Nothing -> Just [k2]
-      Just arr -> Just (arr <> [k2])) a)  r
-    pure $ void $ liftST $ Ref.modify (Map.alter (case _ of
-      Nothing -> Nothing
-      Just arr -> Just (deleteBy unsafeRefEq k2 arr)) a) r
+    void $ liftST $ Ref.modify
+      ( Map.alter
+          ( case _ of
+              Nothing -> Just [ k2 ]
+              Just arr -> Just (arr <> [ k2 ])
+          )
+          a
+      )
+      r
+    pure $ void $ liftST $ Ref.modify
+      ( Map.alter
+          ( case _ of
+              Nothing -> Nothing
+              Just arr -> Just (deleteBy unsafeRefEq k2 arr)
+          )
+          a
+      )
+      r
   unsub <- subscribe e \a -> do
     o <- liftST $ Ref.read r
-    case Map.lookup a o of
+    case Map.lookupLE a o of
       Nothing -> pure unit
-      Just arr -> for_ arr (_ $ unit)
+      Just { key, value } -> when (key == a) (for_ value (_ $ key))
   pure do
     -- free references - helps gc?
     void $ liftST $ Ref.write (Map.empty) r

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -34,6 +34,17 @@ import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
 import Type.Proxy (Proxy(..))
 
+data Silly = Silly Int Int
+
+instance Eq Silly where
+  eq (Silly a _) (Silly b _) = a == b
+
+instance Ord Silly where
+  compare (Silly a _) (Silly b _) = a `compare` b
+
+instance Show Silly where
+  show (Silly a b) = "Silly " <> show a <> " " <> show b
+
 refToBehavior :: Ref.Ref ~> Behavior
 refToBehavior r = behavior \e -> makeEvent \k -> Event.subscribe e \f -> Ref.read r >>=
   (k <<< f)
@@ -569,21 +580,21 @@ main = do
           it "mailboxes" $ liftEffect do
             rf <- Ref.new []
             e <- Event.create
-            unsub <- Event.subscribe (keepLatest $ mailboxed e.event \f -> f 3 <|> f 4) \i -> Ref.modify_ (cons i) rf
-            e.push 42
-            e.push 43
-            e.push 44
-            e.push 3 --
-            e.push 42
-            e.push 43
-            e.push 44
-            e.push 4 --
-            e.push 42
-            e.push 43
-            e.push 3 --
-            e.push 101
+            unsub <- Event.subscribe (keepLatest $ mailboxed e.event \f -> f (Silly 3 42) <|> f (Silly 4 555)) \i -> Ref.modify_ (cons i) rf
+            e.push (Silly 42 1)
+            e.push (Silly 43 1)
+            e.push (Silly 44 1)
+            e.push (Silly 3 1) --
+            e.push (Silly 42 1)
+            e.push (Silly 43 1)
+            e.push (Silly 44 1)
+            e.push (Silly 4 1) --
+            e.push (Silly 42 1)
+            e.push (Silly 43 1)
+            e.push (Silly 3 1) --
+            e.push (Silly 101 1)
             o <- Ref.read rf
-            o `shouldEqual` [ 3, 4, 3 ]
+            o `shouldEqual` [ Silly 3 42, Silly 4 555, Silly 3 42 ]
             unsub
         describe "Gate" do
           it "gates" $ liftEffect do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -583,7 +583,7 @@ main = do
             e.push 3 --
             e.push 101
             o <- Ref.read rf
-            o `shouldEqual` [ unit, unit, unit ]
+            o `shouldEqual` [ 3, 4, 3 ]
             unsub
         describe "Gate" do
           it "gates" $ liftEffect do


### PR DESCRIPTION
Currently, the `Ord` instance on `mailboxed` is not used to its fullest potential, as we never know the key stored in the mailbox. This means that if a type has a novel `Eq` implementation, we won't know what it was equal to.
    
This is particularly useful in cases where we have an internal ID and we receive a server-side ID. In that case, we can have:
    
```purescript
data InternalId = InternalId ClientId ServerId
    
instance Eq InternalId where
      eq (InternalId cid0 _) (InternalId cid1 _) = cid0 == cid1
```

Equality is only defined in terms of the client side id, and when mailboxed is used, we can listen for the client-side ID to get the server side id. In this way, "mailboxed" can be used to deliver arbitrary payloads to listeners.